### PR TITLE
Single source package version and print it

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.0.5] - 2021-01-09
+- Added flag to print version in a single-sourced way
+
 ## [0.0.4] - 2020-12-27
 - Added integration tests
 

--- a/photomatrix/arguments.py
+++ b/photomatrix/arguments.py
@@ -7,6 +7,11 @@ from math import ceil, sqrt
 from pathlib import Path
 from PIL import Image
 from fonts.ttf import SourceSansProSemibold as DefaultFont
+try:
+    from importlib import metadata
+except ImportError:
+    # on Python <3.8 use importlib-metadata package
+    import importlib_metadata as metadata
 
 
 class RunConfig:
@@ -177,6 +182,7 @@ def hexadecimal_color(string_value):
 
 def parse_arguments(args):
     parser = argparse.ArgumentParser(prog='photomatrix', description='Concat photos together in a matrix.')
+    parser.add_argument('--version', action='version', version=metadata.version(parser.prog))
     parser.add_argument('input_images', type=file_paths,
                         help='the path to the images to be processed. '
                              'Can contain *, ?, and character ranges expressed with [].')

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open("README.md", "r") as fh:
 
 setuptools.setup(
     name="photomatrix",
-    version="0.0.4",
+    version="0.0.5",
     author="Francesco Feltrinelli",
     description="Concat photos together in a matrix",
     long_description=long_description,
@@ -20,6 +20,7 @@ setuptools.setup(
     ],
     python_requires='>=3.7',
     install_requires=[
+        'importlib-metadata ~= 1.0 ; python_version < "3.8"',
         'pillow>=7',
         'fonts',
         'font-source-sans-pro'

--- a/tests/integration/test_version.py
+++ b/tests/integration/test_version.py
@@ -1,0 +1,18 @@
+from photomatrix import __main__ as photomatrix
+import pytest
+try:
+    from importlib import metadata
+except ImportError:
+    # on Python <3.8 use importlib-metadata package
+    import importlib_metadata as metadata
+
+
+def test_printed_version(capsys):
+    expected_version = metadata.version('photomatrix')
+
+    with pytest.raises(SystemExit):
+        photomatrix.main(['--version'])
+
+    actual_output = capsys.readouterr().out.rstrip()
+    assert actual_output, 'No output found'
+    assert actual_output == expected_version


### PR DESCRIPTION
Added `--version` flag to print package version. The version is single sourced from `setup.py` and imported wherever needed with `importlib.metadata`.

Fixes #6 .